### PR TITLE
Speed up recognition of incoming response

### DIFF
--- a/pylovepdf/ilovepdf.py
+++ b/pylovepdf/ilovepdf.py
@@ -33,11 +33,12 @@ class ILovePdf(object):
 
         """
 
-    def __init__(self, public_key, verify_ssl=True):
+    def __init__(self, public_key, verify_ssl=True, proxies=None):
 
         # auto explaining
         self.public_key = public_key
         self.ssl = verify_ssl
+        self.proxies = proxies
 
         # Currently not used
         self.secret_key = ''
@@ -68,7 +69,7 @@ class ILovePdf(object):
 
         self.working_server = working_server
 
-    def _send_request(self, method, endpoint, payload, headers=None, start=False, files=None, stream=None):
+    def _send_request(self, method, endpoint, payload, headers=None, start=False, files=None, stream=None, proxies=None):
 
         server = self.start_server
 
@@ -76,7 +77,7 @@ class ILovePdf(object):
             server = self.working_server
 
         url = 'https://' + server + '/' + self.api_version + '/' + endpoint
-        response = Request.send(method, url, payload, headers, files, stream, verify_ssl=self.ssl)
+        response = Request.send(method, url, payload, headers, files, stream, verify_ssl=self.ssl, proxies=self.proxies)
 
         return response
 
@@ -100,4 +101,4 @@ class ILovePdf(object):
         module_name = importlib.import_module('.tools.' + tool.lower(), package='pylovepdf')
         class_name = getattr(module_name, tool.title())
 
-        return class_name(self.public_key, self.ssl)
+        return class_name(self.public_key, self.ssl, self.proxies)

--- a/pylovepdf/request.py
+++ b/pylovepdf/request.py
@@ -9,12 +9,12 @@ requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
 class Request(object):
 
     @staticmethod
-    def send(method, url, payload, headers=None, files=None, stream=None, verify_ssl=True):
+    def send(method, url, payload, headers=None, files=None, stream=None, verify_ssl=True, proxies=None):
 
         if method == 'post':
-            response = requests.post(url, headers=headers, data=payload, files=files, verify=verify_ssl, stream=stream)
+            response = requests.post(url, headers=headers, data=payload, files=files, verify=verify_ssl, stream=stream, proxies=proxies)
         else:
-            response = requests.get(url, headers=headers, data=payload, files=files, verify=verify_ssl, stream=stream)
+            response = requests.get(url, headers=headers, data=payload, files=files, verify=verify_ssl, stream=stream, proxies=proxies)
 
         return Response(response)
 

--- a/pylovepdf/response.py
+++ b/pylovepdf/response.py
@@ -6,26 +6,26 @@ class Response(object):
     def __init__(self, response):
 
         self.status = response.status_code
-
         try:
-            params = json.JSONDecoder().decode(response.text)
-
-            for attr, value in params.items():
-                setattr(self, attr, value)
-
-        except json.decoder.JSONDecodeError:
-            # if it's not json, it's the incoming pdf file or empty response
-            # deleting a task will not output anything from ilovepdf.com, so:
-            if 'application/pdf' in response.headers['content-type']:
+            headers = response.headers['content-type']
+            if 'application/pdf' in headers:
                 setattr(self, 'headers', response.headers)
                 setattr(self, 'iter_content', response.iter_content)
-            elif 'application/zip' in response.headers['content-type']:
+            elif 'application/zip' in headers:
                 setattr(self, 'headers', response.headers)
                 setattr(self, 'iter_content', response.iter_content)
-            elif 'image/jpeg'in response.headers['content-type']:
+            elif 'image/jpeg'in headers:
                 setattr(self, 'headers', response.headers)
                 setattr(self, 'iter_content', response.iter_content)
             else:
+                raise KeyError
+        except KeyError:
+            try:
+                params = json.JSONDecoder().decode(response.text)
+
+                for attr, value in params.items():
+                    setattr(self, attr, value)
+            except json.decoder.JSONDecodeError:
                 pass
 
     def __str__(self):

--- a/pylovepdf/task.py
+++ b/pylovepdf/task.py
@@ -7,7 +7,7 @@ class Task(ILovePdf):
 
     tool = ''
 
-    def __init__(self, public_key, start=False, verify_ssl=True):
+    def __init__(self, public_key, start=False, verify_ssl=True, proxies=None):
 
         self.files = []
         self.downloaded_file_extension = ''
@@ -15,8 +15,9 @@ class Task(ILovePdf):
         self.download_path = ''
         self.task = ''
         self.status = ''
+        self.proxies = proxies
 
-        super(Task, self).__init__(public_key)
+        super(Task, self).__init__(public_key, proxies=self.proxies)
 
         self.begin = start
         self.file = None
@@ -44,14 +45,14 @@ class Task(ILovePdf):
 
         payload = {"public_key": self.public_key}
 
-        response = self._send_request('post', 'auth', payload, None, self.begin)
+        response = self._send_request('post', 'auth', payload, None, self.begin, proxies=self.proxies)
         self._set_token(response.token)
         self._set_headers()
 
     def start(self):
 
         headers = self.headers
-        response = self._send_request('get', 'start/' + self.tool, None, headers, self.begin)
+        response = self._send_request('get', 'start/' + self.tool, None, headers, self.begin, proxies=self.proxies)
         self._set_working_server(response.server)
 
         self.task = response.task
@@ -71,7 +72,7 @@ class Task(ILovePdf):
 
             with open(file.filename, 'rb') as f:
                 response = self._send_request('post', 'upload', payload=payload, headers=self.headers,
-                                              files={"file": f})
+                                              files={"file": f}, proxies=self.proxies)
 
             file.server_filename = response.server_filename
 
@@ -167,7 +168,7 @@ class Task(ILovePdf):
 
         payload = self.process()
 
-        response = self._send_request('post', 'process', payload, self.headers)
+        response = self._send_request('post', 'process', payload, self.headers, proxies=self.proxies)
 
         print("File uploaded! Below file stats:")
         self.status = response.status
@@ -181,7 +182,7 @@ class Task(ILovePdf):
     def check_task_status(self, printall=False):
 
         response = self._send_request('get', 'task/%s' % self.task, None, self.headers, False,
-                                      None, stream=False)
+                                      None, stream=False, proxies=self.proxies)
 
         if printall:
             print(response)
@@ -200,7 +201,7 @@ class Task(ILovePdf):
             print('Downloading processed file...')
 
             response = self._send_request('get', 'download/%s' % self.task, None, self.headers, False,
-                                          None, stream=True)
+                                          None, stream=True, proxies=self.proxies)
 
             # file_ext = str(response.headers['content-type']).split('/')
 
@@ -220,7 +221,7 @@ class Task(ILovePdf):
 
     def delete_current_task(self):
 
-        response = self._send_request('post', 'task/' + self.task, None, headers=self.headers)
+        response = self._send_request('post', 'task/' + self.task, None, headers=self.headers, proxies=self.proxies)
         print("Task delete %s" % response)
 
 

--- a/pylovepdf/tools/compress.py
+++ b/pylovepdf/tools/compress.py
@@ -9,12 +9,12 @@ class Compress(Task):
 
     """
 
-    def __init__(self, public_key, verify_ssl):
+    def __init__(self, public_key, verify_ssl, proxies):
 
         self.tool = 'compress'
         self.compression_level = 'recommended'
 
-        super(Compress, self).__init__(public_key, True, verify_ssl)
+        super(Compress, self).__init__(public_key, True, verify_ssl, proxies)
 
     @property
     def allowed_properties(self):

--- a/pylovepdf/tools/imagetopdf.py
+++ b/pylovepdf/tools/imagetopdf.py
@@ -3,7 +3,7 @@ from pylovepdf.task import Task
 
 class ImageToPdf(Task):
 
-    def __init__(self, public_key, verify_ssl):
+    def __init__(self, public_key, verify_ssl, proxies):
 
         self.orientation = 'portrait'
         self.margin = 0
@@ -11,7 +11,7 @@ class ImageToPdf(Task):
         self.merge_after = True
 
         self.tool = 'imagepdf'
-        super(ImageToPdf, self).__init__(public_key, True, verify_ssl)
+        super(ImageToPdf, self).__init__(public_key, True, verify_ssl, proxies)
 
     @property
     def allowed_properties(self):

--- a/pylovepdf/tools/merge.py
+++ b/pylovepdf/tools/merge.py
@@ -3,10 +3,10 @@ from pylovepdf.task import Task
 
 class Merge(Task):
 
-    def __init__(self, public_key, verify_ssl):
+    def __init__(self, public_key, verify_ssl, proxies):
 
         self.tool = 'merge'
-        super(Merge, self).__init__(public_key, True, verify_ssl)
+        super(Merge, self).__init__(public_key, True, verify_ssl, proxies)
 
 
 

--- a/pylovepdf/tools/unlock.py
+++ b/pylovepdf/tools/unlock.py
@@ -3,10 +3,10 @@ from pylovepdf.task import Task
 
 class Unlock(Task):
 
-    def __init__(self, public_key, verify_ssl):
+    def __init__(self, public_key, verify_ssl, proxies):
 
         self.tool = 'unlock'
-        super(Unlock, self).__init__(public_key, True, verify_ssl)
+        super(Unlock, self).__init__(public_key, True, verify_ssl, proxies)
 
 
 

--- a/pylovepdf/tools/validatepdfa.py
+++ b/pylovepdf/tools/validatepdfa.py
@@ -3,12 +3,12 @@ from pylovepdf.task import Task
 
 class ValidatePdfA(Task):
 
-    def __init__(self, public_key, verify_ssl):
+    def __init__(self, public_key, verify_ssl, proxies):
 
         self.tool = 'validatepdfa'
         self.conformance = 'pdfa-2b'
 
-        super(ValidatePdfA, self).__init__(public_key, True, verify_ssl)
+        super(ValidatePdfA, self).__init__(public_key, True, verify_ssl, proxies)
 
     @property
     def allowed_properties(self):

--- a/pylovepdf/tools/watermark.py
+++ b/pylovepdf/tools/watermark.py
@@ -3,7 +3,7 @@ from pylovepdf.task import Task
 
 class Watermark(Task):
 
-    def __init__(self, public_key, verify_ssl):
+    def __init__(self, public_key, verify_ssl, proxies):
 
         self.tool = 'watermark'
 
@@ -25,7 +25,7 @@ class Watermark(Task):
         self.font_color = '#000000'
         self.transparency = 100
 
-        super(Watermark, self).__init__(public_key, True, verify_ssl)
+        super(Watermark, self).__init__(public_key, True, verify_ssl, proxies)
 
     @property
     def allowed_properties(self):


### PR DESCRIPTION
The try/except KeyError formerly used has one setback : it could be very long when "big" pdf are coming from the server. Some clues let me think it may be linked to json (failing to detect used encoding for response.text, which doesn't seem that awkward to me...).