### PR TITLE
Add method for retrieving task information

### DIFF
--- a/pylovepdf/task.py
+++ b/pylovepdf/task.py
@@ -225,5 +225,13 @@ class Task(ILovePdf):
         response = self._send_request('post', 'task/' + self.task, None, headers=self.headers, proxies=self.proxies)
         print("Task delete %s" % response)
 
-
+    def get_task_information(self):
+        """
+        Give information about a task status.
+        If the task is TaskSuccess, TaskSuccessWithWarnings or TaskError it will also specify all files of the Task
+        and their status one by one.
+        :return: Response of the request.
+        """
+        return self._send_request('get', 'task/%s' % self.task, None, self.headers, False,
+                                      None, stream=False, proxies=self.proxies)
 


### PR DESCRIPTION
A method is added to the Task class which sends an API request to get information about the status of a task. This enables applications which use this library to get more in depth information about a task, such as the total file size uploaded and the total file size downloaded.