### PR TITLE
Fix renaming bug after downloading

### DIFF
--- a/pylovepdf/task.py
+++ b/pylovepdf/task.py
@@ -196,8 +196,7 @@ class Task(ILovePdf):
 
     def clean_filename(self, filename):
 
-        name = filename.split('_')
-        return name[len(name)-3] + '_' + name[len(name)-2] + '_' + name[len(name)-1]
+        return "_".join(filename.split('_')[1:])
 
     def download(self):
 


### PR DESCRIPTION
The clean_filename method incorrectly renamed `a_b_c.pdf` to `c.pdf` . This is now fixed.

After splitting the filename on `_`, only the last three splits were taken. If the original filename consisted of more `_` separated parts, these were ignored and not shown in the final filename.
Now, the filename is still splitted on `_`, but every split except the first one is taken and joined with `_`.

An example of how it went wrong:
The compressed file of `a_b_c.pdf` was named `c_compress_23-09-2019.pdf`.
Now, the compressed file of `a_b_c.pdf` is named `a_b_c_compress_23-09-2019.pdf`.