### PR TITLE
Fix renaming bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# pylovepdf 1.3.2
+# pylovepdf 1.3.3
 
 ilovepdf.com python API library
 

--- a/pylovepdf/task.py
+++ b/pylovepdf/task.py
@@ -2,6 +2,7 @@ from pylovepdf.ilovepdf import ILovePdf
 from pylovepdf.file import File
 import re
 import os
+import uuid
 
 
 class Task(ILovePdf):
@@ -195,8 +196,14 @@ class Task(ILovePdf):
             return response.status
 
     def clean_filename(self, filename):
-
-        return "_".join(filename.split('_')[1:])
+        """
+        Clean filename from additional suffixes added by the server.
+        Assures zip filename uniquess by adding a randomly generated string prefix.
+        :param filename: filename to process
+        """
+        if ".zip" in filename:
+            return str(uuid.uuid1())[:8]+ '_' + filename
+        return "_".join(filename.split('_')[:-2]) + '.' + filename.rsplit(".", 1)[-1]
 
     def download(self):
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ def readme():
 
 
 setup(name='pylovepdf',
-      version='1.3.2',
+      version='1.3.3',
       description='ilovepdf.com python API library',
       long_description=readme(),
       classifiers=[


### PR DESCRIPTION
- Update version
- Fix file renaming

Previous fix removed the original name of single submitted file.
If several files were submitted and a zip was returned, the name was also not maintained.
This proposed fix maintains the original filename and add a prefix to received zips to avoid name collision durante concurrent processing.