### PR TITLE
fix officepdf

### DIFF
--- a/pylovepdf/tools/officepdf.py
+++ b/pylovepdf/tools/officepdf.py
@@ -1,14 +1,9 @@
 from pylovepdf.task import Task
 
 
-class OfficeToPdf(Task):
+class Officepdf(Task):
 
     def __init__(self, public_key, verify_ssl, proxies):
 
         self.tool = 'officepdf'
-        super(OfficeToPdf, self).__init__(public_key, True, verify_ssl, proxies)
-
-
-
-
-
+        super(Officepdf, self).__init__(public_key, True, verify_ssl, proxies)


### PR DESCRIPTION
Hello,

There was a little misspell
error from original code:
```
site-packages\pylovepdf\ilovepdf.py", line 102, in new_task
    class_name = getattr(module_name, tool.title())

AttributeError: module 'pylovepdf.tools.officepdf' has no attribute 'Officepdf'
```